### PR TITLE
Add privacy policy for the sake of publishing to chrome

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,53 @@
+# Privacy Policy for DataHub-Link-Generator Chrome Extension
+
+**Effective Date**: 06/23/2025
+
+The DataHub-Link-Generator Chrome Extension ("the Extension") respects your privacy. This Privacy Policy outlines the information we collect, how we use it, and the steps we take to protect your information when you use the Extension to generate links for launching notebooks in JupyterHub specific to Berkeley.
+
+## 1. Information We Collect
+
+### a. Personal Information
+- The Extension does not require you to create an account or provide personal information such as your name, email address, or contact information.
+
+### b. Usage Information
+- **GitHub Data**: When you use the Extension to generate links, it accesses the URL of the GitHub repository to verify its validity and to extract notebook links.
+- **Technical Data**: We may collect non-identifying information about your device and how you interact with the Extension, such as IP address, browser type, and operating system.
+
+### c. Cookies and Tracking
+- The Extension does not use cookies or similar tracking technologies to monitor its use.
+
+## 2. How We Use Your Information
+
+- **Functionality**: The primary use of the collected information is to construct unique JupyterHub links, facilitating seamless access to Berkeley-specific notebooks.
+- **Performance Improvement**: We analyze the usage data to optimize and improve the Extension’s functionality.
+- **Legal Compliance**: Information may be used to comply with applicable legal requirements.
+
+## 3. Information Sharing and Disclosure
+
+- **Service Providers**: We do not share your information with third-party service providers unless it's necessary for providing or improving the Extension.
+- **Compliance and Legal Obligations**: Information may be disclosed to comply with legal obligations, such as responding to subpoenas, court orders, or other legal processes.
+- **Business Transfers**: In the event of a merger, acquisition, or sale, information may be transferred as part of that transaction.
+
+## 4. Data Security
+
+While no electronic transmission or electronic storage method is entirely secure, we implement reasonable security measures to protect your information from unauthorized access, alteration, or destruction.
+
+## 5. Your Rights and Choices
+
+- **Access and Correction**: Since we do not store personal data, there are no specific access rights applicable. For any questions or concerns, please contact us.
+- **Data Deletion**: As no personal information is collected, there is no personal data to delete.
+
+## 6. Third-Party Links
+
+The Extension may contain links to third-party websites. We are not responsible for the privacy practices or content of these sites. We recommend reviewing their privacy policies.
+
+## 7. Changes to This Privacy Policy
+
+We may update this Privacy Policy occasionally. Significant changes will be communicated by updating the policy on this page with a new effective date.
+
+## 8. Contact Us
+
+For any questions or concerns about this Privacy Policy, please contact us at:
+- **Email**: nbgitpuller-ucb@berkeley.edu
+
+By using the DataHub-Link-Generator Chrome Extension, you agree to this Privacy Policy's terms. We appreciate your trust in handling your information responsibly.


### PR DESCRIPTION
- Publishing the extension to Chrome requires a privacy policy
- Added a preliminary one for now

We can review it further and tweak it in the upcoming months.